### PR TITLE
Hide proprietary environment variables

### DIFF
--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -1,12 +1,12 @@
 import * as firebase from 'firebase';
 
 const config = {
-  apiKey: "AIzaSyDod6DA83q2ScDKUvc_icUP_U8tCwL0Ifc",
-  authDomain: "fileit-2a109.firebaseapp.com",
-  databaseURL: "https://fileit-2a109.firebaseio.com",
-  projectId: "fileit-2a109",
-  storageBucket: "fileit-2a109.appspot.com",
-  messagingSenderId: "524858754740"
+  apiKey: process.env.REACT_APP_apiKey,
+  authDomain: process.env.REACT_APP_authDomain,
+  databaseURL: process.env.REACT_APP_databaseURL,
+  projectId: process.env.REACT_APP_projectId,
+  storageBucket: process.env.REACT_APP_storageBucket,
+  messagingSenderId: process.env.REACT_APP_messagingSenderId
 };
 
 firebase.initializeApp(config);


### PR DESCRIPTION
The project was built with create-react-app which has the dotenv package built in. Use the dotenv functionality to hide the environment variables from source control and malicious users.

closes #25 