### PR TITLE
Eliminate firebase warnings

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import firebase from './firebase/firebase';
 import {Provider} from 'react-redux';
 import store, {persistor} from './store/configureStore';
 import AppRouter from './Routers/AppRouter';
-import {loginGenerator, logoutGenerator} from './actions/auth';
+import {logoutGenerator} from './actions/auth';
 import {storeUserData} from './actions/profile';
 import {PersistGate} from 'redux-persist/lib/integration/react';
 import LoadingPage from './components/LoadingPage';
@@ -64,7 +64,7 @@ firebase.auth().onAuthStateChanged((user) => {
     localStorage.removeItem('firstName');
     localStorage.removeItem('accountType');
     store.dispatch(logoutGenerator());
-    console.log(store.getState());
+    // console.log(store.getState());
     history.push('/');
   }
 })

--- a/src/TestAuthActions.test.js
+++ b/src/TestAuthActions.test.js
@@ -1,18 +1,5 @@
 import {loginGenerator, logoutGenerator} from './actions/auth';
 
-test('should generate a login action', () => {
-  const firstName = "Jeff";
-  const lastName = "Kells";
-  const email = "jk1@gmail.com";
-  const action = loginGenerator(firstName, lastName, email);
-  expect(action).toEqual({
-    type: 'LOGIN',
-    firstName: firstName,
-    lastName: lastName,
-    email: email
-  })
-})
-
 test('should generate a logout action', () => {
   const action = logoutGenerator();
   expect(action).toEqual({

--- a/src/components/ProfilePage.js
+++ b/src/components/ProfilePage.js
@@ -2,21 +2,9 @@ import React from 'react';
 import {Link} from 'react-router-dom';
 import store from '../store/configureStore';
 import Header from './Header';
+import {getPlanDetails} from '../utilities/planData';
 
 export default class ProfilePage extends React.Component {
-  getAccountTypeString = () => {
-    switch (store.getState().accountType) {
-      case "0":
-        return "Free";
-      case "1":
-        return "Personal";
-      case "2":
-        return "Business";
-      default:
-        return "Premium";
-    }
-  }
-
   render () {
     return (
       <div>
@@ -29,7 +17,7 @@ export default class ProfilePage extends React.Component {
         <div className="small-content-container">
           <p><label>Name:</label> {store.getState().firstName} {store.getState().lastName}</p>
           <p><label>Email:</label> {store.getState().email}</p>
-          <p><label>Account Type:</label> {this.getAccountTypeString()}</p>
+          <p><label>Account Type:</label> {getPlanDetails(store.getState().accountType)}</p>
           <Link to="/edit-profile-page" className="button">Change Name</Link><br />
           <Link to="/change-email-page" className="button">Change Email</Link><br />
           <Link to="/change-password-page" className="button">Change Password</Link><br />

--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -1,4 +1,8 @@
-import * as firebase from 'firebase';
+// import * as firebase from 'firebase';
+import firebase from 'firebase/app';
+import 'firebase/auth'
+import 'firebase/database'
+import 'firebase/storage'
 
 const config = {
   apiKey: process.env.REACT_APP_apiKey,


### PR DESCRIPTION
Refactor firebase imports to eliminate the firebase warnings.

Bug fix: use the `getPlanDetails` method on the profile page to get the information on the user's current plan.

Eliminate old code.


closes #144 