### PR TITLE
148 add ability to change account type

### DIFF
--- a/src/actions/profile.js
+++ b/src/actions/profile.js
@@ -7,25 +7,32 @@ export const storeUserData = (firstName, lastName, email, accountType) => {
     email,
     accountType
   }
-}
+};
 
 export const storeUserCredential = (credential) => {
   return {
     type: 'STORE_USER_CREDENTIAL',
     credential
   }
-}
+};
 
 export const updateEmail = (email) => {
   return {
     type: 'UPDATE_EMAIL',
     email
   }
-}
+};
 
-export const setOrderValues = (accountType) => {
+export const setOrderValues = (newAccountType) => {
   return {
     type: 'SET_ORDER_VALUES',
+    newAccountType
+  }
+};
+
+export const setAccountType = (accountType) => {
+  return {
+    type: 'SET_ACCOUNT_TYPE',
     accountType
   }
-}
+};

--- a/src/components/CheckoutPage.js
+++ b/src/components/CheckoutPage.js
@@ -5,11 +5,13 @@ import Header from './Header';
 import {getPlanPrice, getPlanDetails} from '../utilities/planData';
 import {history} from '../App';
 import {setAccountType} from "../actions/profile";
+import firebase from '../firebase/firebase';
 
 export class CheckoutPage extends React.Component {
   onSubmit = (e) => {
     e.preventDefault();
     store.dispatch(setAccountType(this.props.newAccountType));
+    firebase.database().ref('users/' + this.props.user.uid + '/accountType').set(this.props.newAccountType)
     console.log("submitted");
     history.push('/order-confirmation-page');
   }
@@ -132,7 +134,8 @@ export class CheckoutPage extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    newAccountType: state.newAccountType
+    newAccountType: state.newAccountType,
+    user: state.credential.user
   }
 }
 

--- a/src/components/CheckoutPage.js
+++ b/src/components/CheckoutPage.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import {connect} from 'react-redux';
+import store from '../store/configureStore';
 import Header from './Header';
 import {getPlanPrice, getPlanDetails} from '../utilities/planData';
 import {history} from '../App';
+import {setAccountType} from "../actions/profile";
 
 export class CheckoutPage extends React.Component {
   onSubmit = (e) => {
     e.preventDefault();
+    store.dispatch(setAccountType(this.props.newAccountType));
     console.log("submitted");
     history.push('/order-confirmation-page');
   }

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -34,8 +34,13 @@ const rootReducer = (state = {}, action) => {
     case 'SET_ORDER_VALUES':
       return {
         ...state,
-        newAccountType: action.accountType
+        newAccountType: action.newAccountType
       };
+    case 'SET_ACCOUNT_TYPE':
+      return {
+        ...state,
+        accountType: action.accountType
+      }
     default:
       return state;
   }


### PR DESCRIPTION
Add functionality to change user's accountType when change order is placed. Update Redux store and the Firebase records with the new accountType.

Change the `saveOrderDetails` action to use the key `newAccountType` to be more clear.

closes #148 