### PR TITLE
Make file icons wrap at edge of screen

### DIFF
--- a/src/css/DashboardPage.css
+++ b/src/css/DashboardPage.css
@@ -1,5 +1,6 @@
 .files-list {
   display: flex;
+  flex-flow: wrap;
 }
 
 .file-control {


### PR DESCRIPTION
Add CSS rule to make file icons wrap at the edge of the screen.

closes #156 