### PR TITLE
55 add map dispatch to props to project

### DIFF
--- a/src/actions/profile.js
+++ b/src/actions/profile.js
@@ -9,6 +9,14 @@ export const storeUserData = (firstName, lastName, email, accountType) => {
   }
 };
 
+export const storeUserName = (firstName, lastName) => {
+  return {
+    type: 'STORE_USER_NAME',
+    firstName,
+    lastName
+  }
+}
+
 export const storeUserCredential = (credential) => {
   return {
     type: 'STORE_USER_CREDENTIAL',

--- a/src/components/AccountTypeSelectionPage.js
+++ b/src/components/AccountTypeSelectionPage.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import store from '../store/configureStore';
 import {connect} from 'react-redux';
 import Header from './Header';
 import {getPlanPrice} from '../utilities/planData';
@@ -9,7 +8,6 @@ import {history} from '../App';
 export class AccountTypeSelectionPage extends React.Component {
   constructor (props) {
     super(props);
-    // const accountType = store.getState().accountType;
     const accountType = props.accountType;
 
     this.state = {
@@ -20,7 +18,6 @@ export class AccountTypeSelectionPage extends React.Component {
   }
 
   onRadioChange = (e) => {
-    // const currentPrice = getPlanPrice(store.getState().accountType);
     const currentPrice = getPlanPrice(this.props.accountType);
     const newAccountType = e.target.value;
     const difference = getPlanPrice(newAccountType) - currentPrice;
@@ -32,8 +29,9 @@ export class AccountTypeSelectionPage extends React.Component {
 
   onSubmit = (e) => {
     e.preventDefault();
-    store.dispatch(setOrderValues(this.state.accountType));
-    history.push('/checkout')
+    // store.dispatch(setOrderValues(this.state.accountType));
+    this.props.onSubmit(this.state.accountType);
+    history.push('/checkout');
   };
 
   render () {
@@ -119,5 +117,18 @@ const mapStateToProps = (state) => {
   }
 };
 
+// The mapStateToProps function has the result of store.getState() automatically passed in as the first parameter.
+// The mapDispatchToProps function has the store.dispatch function automatically passed in as the first parameter.
+// The mapDispatchToProps function returns an object whose properties become available as props on our component.
+// To use it, create an arrow function that accepts whatever external input you want to pass into the function (or
+// it's nested functions). Have it call the dispatch function (and any action generators). Thus the prop becomes a
+// function that, when invoked, calls store.dispatch with the appropriate action generator and passes into the action
+// generator the value that you supplied.
+const mapDispatchToProps = (dispatch) => {
+  return {
+    onSubmit: (accountType) => dispatch(setOrderValues(accountType))
+  }
+};
+
 // ConnectedAccountTypeSelectionPage
-export default connect(mapStateToProps)(AccountTypeSelectionPage)
+export default connect(mapStateToProps, mapDispatchToProps)(AccountTypeSelectionPage)

--- a/src/components/CheckoutPage.js
+++ b/src/components/CheckoutPage.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import store from '../store/configureStore';
 import Header from './Header';
 import {getPlanPrice, getPlanDetails} from '../utilities/planData';
 import {history} from '../App';
@@ -10,7 +9,6 @@ import firebase from '../firebase/firebase';
 export class CheckoutPage extends React.Component {
   onSubmit = (e) => {
     e.preventDefault();
-    // store.dispatch(setAccountType(this.props.newAccountType));
     this.props.onSubmit(this.props.newAccountType);
     firebase.database().ref('users/' + this.props.user.uid + '/accountType').set(this.props.newAccountType)
     console.log("submitted");

--- a/src/components/CheckoutPage.js
+++ b/src/components/CheckoutPage.js
@@ -10,7 +10,8 @@ import firebase from '../firebase/firebase';
 export class CheckoutPage extends React.Component {
   onSubmit = (e) => {
     e.preventDefault();
-    store.dispatch(setAccountType(this.props.newAccountType));
+    // store.dispatch(setAccountType(this.props.newAccountType));
+    this.props.onSubmit(this.props.newAccountType);
     firebase.database().ref('users/' + this.props.user.uid + '/accountType').set(this.props.newAccountType)
     console.log("submitted");
     history.push('/order-confirmation-page');
@@ -137,7 +138,13 @@ const mapStateToProps = (state) => {
     newAccountType: state.newAccountType,
     user: state.credential.user
   }
-}
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    onSubmit: (newAccountType) => dispatch(setAccountType(newAccountType))
+  }
+};
 
 // ConnectedCheckoutPage
-export default connect(mapStateToProps)(CheckoutPage)
+export default connect(mapStateToProps, mapDispatchToProps)(CheckoutPage)

--- a/src/components/CreateAccountForm.js
+++ b/src/components/CreateAccountForm.js
@@ -2,9 +2,9 @@ import React from 'react';
 import firebase from '../firebase/firebase';
 import {Link} from 'react-router-dom';
 import {storeUserData, storeUserCredential} from '../actions/profile';
-import store from '../store/configureStore';
+import {connect} from 'react-redux';
 
-export default class CreateAccountForm extends React.Component {
+export class CreateAccountForm extends React.Component {
   constructor(props) {
     super(props);
 
@@ -32,8 +32,8 @@ export default class CreateAccountForm extends React.Component {
           credential.user.updateProfile({
             displayName: firstName
           })
-          store.dispatch(storeUserData(firstName, lastName, email, accountType));
-          store.dispatch(storeUserCredential(credential));
+          this.props.storeUserData(firstName, lastName, email, accountType);
+          this.props.storeUserCredential(credential);
           firebase.database().ref('users/' + credential.user.uid).set({
             lastName,
             accountType
@@ -74,3 +74,13 @@ export default class CreateAccountForm extends React.Component {
     )
   }
 }
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    storeUserData: (firstName, lastName, email, accountType) => dispatch(storeUserData(firstName, lastName, email, accountType)),
+    storeUserCredential: (credential) => dispatch(storeUserCredential(credential))
+  }
+};
+
+// ConnectedCreateAccountForm
+export default connect(undefined, mapDispatchToProps)(CreateAccountForm)

--- a/src/components/DeleteAccountPage.js
+++ b/src/components/DeleteAccountPage.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
-import store from '../store/configureStore';
 import Header from './Header';
 import firebase from '../firebase/firebase';
 import {logoutGenerator} from '../actions/auth';
+import {connect} from 'react-redux';
 
-export default class DeleteAccountPage extends React.Component {
+export class DeleteAccountPage extends React.Component {
 
   onDeleteSelected = (e) => {
     console.log('button clicked');
@@ -13,7 +13,7 @@ export default class DeleteAccountPage extends React.Component {
     const user = firebase.auth().currentUser;
     firebase.database().ref('users/' + user.uid).remove()
       .then(() => {
-        store.dispatch(logoutGenerator());
+        this.props.logout();
         return user.delete();
       })
       .catch(() => {
@@ -41,3 +41,12 @@ export default class DeleteAccountPage extends React.Component {
     )
   }
 }
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    logout: () => dispatch(logoutGenerator())
+  }
+}
+
+// ConnectedDeleteAccountPage
+export default connect(undefined, mapDispatchToProps)(DeleteAccountPage)

--- a/src/components/EditProfilePage.js
+++ b/src/components/EditProfilePage.js
@@ -5,7 +5,7 @@ import store from '../store/configureStore';
 import {Link} from 'react-router-dom';
 import firebase from '../firebase/firebase';
 import {history} from '../App';
-import {storeUserData} from '../actions/profile';
+import {storeUserName} from '../actions/profile';
 
 export class EditProfilePage extends React.Component {
   constructor(props) {
@@ -31,7 +31,7 @@ export class EditProfilePage extends React.Component {
       })
         .then(() => {
           firebase.database().ref('users/' + user.uid + '/lastName').set(lastName);
-          store.dispatch(storeUserData(firstName, lastName, user.email));
+          this.props.storeUserName(firstName,lastName);
           history.push('/profile-page');
         })
         .catch((error) => {
@@ -72,7 +72,13 @@ const mapStateToProps = (state) => {
     firstName: state.firstName,
     lastName: state.lastName
   }
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    storeUserName: (firstName, lastName) => dispatch(storeUserName(firstName, lastName))
+  }
 }
 
 // ConnectedEditProfilePage
-export default connect(mapStateToProps)(EditProfilePage);
+export default connect(mapStateToProps, mapDispatchToProps)(EditProfilePage);

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,4 @@
 import React from 'react';
-// import store from '../store/configureStore';
 import {Link} from 'react-router-dom';
 import firebase from '../firebase/firebase';
 import {history} from '../App';
@@ -11,12 +10,12 @@ export class Header extends React.Component {
     e.preventDefault();
     firebase.auth().signOut();
     history.push('/');
-  }
+  };
 
   onDashboardNavigation = (e) => {
     e.preventDefault();
     loadDashBoard();
-  }
+  };
 
   render () {
     return (

--- a/src/components/SignInForm.js
+++ b/src/components/SignInForm.js
@@ -3,8 +3,9 @@ import {Link} from 'react-router-dom';
 import firebase from '../firebase/firebase';
 import store from '../store/configureStore';
 import {storeUserCredential} from '../actions/profile';
+import {connect} from 'react-redux';
 
-export default class SignInForm extends React.Component {
+export class SignInForm extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -20,7 +21,7 @@ export default class SignInForm extends React.Component {
 
     firebase.auth().signInWithEmailAndPassword(email, password)
       .then((credential) => {
-        store.dispatch(storeUserCredential(credential));
+        this.props.storeUserCredential(credential);
       })
       .catch((error) => {
         this.setState(() => ({error: error.message}))
@@ -52,3 +53,12 @@ export default class SignInForm extends React.Component {
     )
   }
 }
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    storeUserCredential: (credential) => dispatch(storeUserCredential(credential))
+  }
+}
+
+// ConnectedSignInForm
+export default connect(undefined, mapDispatchToProps)(SignInForm)

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -16,6 +16,12 @@ const rootReducer = (state = {}, action) => {
         email: action.email,
         accountType: action.accountType
       };
+    case 'STORE_USER_NAME':
+      return {
+        ...state,
+        firstName: action.firstName,
+        lastName: action.lastName
+      };
     case 'STORE_USER_CREDENTIAL':
       return {
         ...state,


### PR DESCRIPTION
Add `mapDispatchToProps` to eliminate `store` imports. Make all `store.dispatch` calls into props. Makes the component more testable.

Eliminate old code.

Create `storeUserName` action generator. Use it to replace the use of `storeUserData` on EditProfilePage.

closes #55 