### PR TITLE
Modify the dashboard page to use state instead of reloading

### DIFF
--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -41,7 +41,7 @@ export const uploadFile = (file) => {
 
 export const addFileNameToFilesData = (file) => {
   const user = firebase.auth().currentUser;
-  firebase.database().ref('users/' + user.uid + '/files').push(file.name);
+  return firebase.database().ref('users/' + user.uid + '/files').push(file.name)
 }
 
 export const changeName = (firstName, lastName) => {


### PR DESCRIPTION
Modify the Dashboard page to use stateful implementation instead of reloading every time a file is added or deleted.

closes #72 