### PR TITLE
172b with stateful file control additions

### DIFF
--- a/src/components/DashboardPage.js
+++ b/src/components/DashboardPage.js
@@ -46,7 +46,8 @@ export class DashboardPage extends React.Component {
 
   onSubmit = (e) => {
     e.preventDefault();
-    const file = document.getElementById('file-upload-page-file-input').files[0];
+    const input = document.getElementById('file-upload-page-file-input');
+    const file = input.files[0];
 
     if (file) {
       const filesData = this.props.filesData;
@@ -55,11 +56,26 @@ export class DashboardPage extends React.Component {
       } else {
         this.uploadTask = uploadFile(file);
         this.uploadId = file.name;
-        addFileNameToFilesData(file);
+        addFileNameToFilesData(file)
+          .then((ref) => {
+            console.log(ref.key);
+            const newFileDataObj = {
+              id: ref.key,
+              filename: file.name
+            };
+            const newFilesData = this.state.filesData.concat([newFileDataObj]);
+            console.log(newFilesData);
+            this.props.setFilesData(newFilesData);
+            this.setState({
+              filesData: newFilesData,
+              error: ''
+            });
+            input.value = '';
+          });
 
-        this.props.startLoadFilesData().then(() => {
-          history.push('/dashboard');
-        })
+        // this.props.startLoadFilesData().then(() => {
+        //   history.push('/dashboard');
+        // })
 
       }
     } else {

--- a/src/components/DashboardPage.js
+++ b/src/components/DashboardPage.js
@@ -14,7 +14,8 @@ export class DashboardPage extends React.Component {
     }
     this.user = props.user;
     this.state = {
-      error: ""
+      error: "",
+      filesData: props.filesData
     };
     this.uploadId = '';
     this.uploadTask = null;
@@ -59,6 +60,7 @@ export class DashboardPage extends React.Component {
         this.props.startLoadFilesData().then(() => {
           history.push('/dashboard');
         })
+
       }
     } else {
       this.setState({
@@ -86,7 +88,7 @@ export class DashboardPage extends React.Component {
         <div className="content-container">
           {this.mainMessage && <p>{this.mainMessage}</p>}
           <div className="files-list">
-            {this.props.filesData.map( (fileDataObj, x) => {
+            {this.state.filesData.map( (fileDataObj, x) => {
               if (this.uploadId && this.uploadId === fileDataObj.filename) {
                 return <FileControl
                   fileDataObj={fileDataObj}

--- a/src/components/DashboardPage.js
+++ b/src/components/DashboardPage.js
@@ -15,13 +15,15 @@ export class DashboardPage extends React.Component {
     this.user = props.user;
     this.state = {
       error: ""
-    }
+    };
+    this.uploadId = '';
+    this.uploadTask = null;
   }
 
   processOverwriteCheck = (file) => {
     const overwrite = window.confirm(file.name + ' already exists. Overwrite?');
     if (overwrite) {
-      uploadFile(file); // without adding filename to list
+      this.uploadTask = uploadFile(file); // without adding filename to list
       this.props.startLoadFilesData().then(() => {
         history.push('/dashboard');
       })
@@ -50,7 +52,8 @@ export class DashboardPage extends React.Component {
       if (this.filenameIsFound(filesData, file.name)) {
         this.processOverwriteCheck(file);
       } else {
-        uploadFile(file);
+        this.uploadTask = uploadFile(file);
+        this.uploadId = file.name;
         addFileNameToFilesData(file);
 
         this.props.startLoadFilesData().then(() => {
@@ -84,9 +87,18 @@ export class DashboardPage extends React.Component {
           {this.mainMessage && <p>{this.mainMessage}</p>}
           <div className="files-list">
             {this.props.filesData.map( (fileDataObj, x) => {
-              return (
-                <FileControl fileDataObj={fileDataObj} key={fileDataObj.id}/>
-              )
+              if (this.uploadId && this.uploadId === fileDataObj.filename) {
+                return <FileControl
+                  fileDataObj={fileDataObj}
+                  key={fileDataObj.id}
+                  uploadTask={this.uploadTask}
+                />
+              } else {
+                return <FileControl
+                  fileDataObj={fileDataObj}
+                  key={fileDataObj.id}
+                />
+              }
             })}
           </div>
         </div>

--- a/src/components/DashboardPage.js
+++ b/src/components/DashboardPage.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {getDownloadURL, deleteFile, removeFileData, uploadFile,
-        addFileNameToFilesData} from '../firebase/firebase';
-import {saveAs} from 'file-saver/FileSaver';
+import {uploadFile, addFileNameToFilesData} from '../firebase/firebase';
 import {setFilesData, startLoadFilesData} from '../actions/files';
+import FileControl from './FileControl';
 import {history} from "../App";
 
 export class DashboardPage extends React.Component {
@@ -65,57 +64,7 @@ export class DashboardPage extends React.Component {
     }
   };
 
-  onFileClick = (e, fileDataObj) => {
-    e.preventDefault();
 
-    const filename = fileDataObj.filename;
-    // firebase.storage().ref().child('files/' + this.user.uid + '/' + filename).getDownloadURL()
-    getDownloadURL(filename)
-      .then( (url) => {
-        const xhr = new XMLHttpRequest();
-        xhr.responseType = 'blob';
-        xhr.onload = function(event) {
-          const blob = xhr.response;
-          saveAs(blob, filename)
-        };
-        xhr.open('GET', url);
-        xhr.send();
-      })
-      .catch( (error) => {
-        alert("An error occurred in the download/n" + error.message)
-      })
-  };
-
-  onDeleteClick = (e) => {
-    const filename = e.target.name;
-    const fileId = e.target.value;
-    if (window.confirm(filename + ' will be Deleted. This CANNOT be undone. Are you sure?')) {
-
-      // first remove the file from storage
-      const storagePromise = deleteFile(filename)
-      .catch((error) => {
-        alert("There was a problem deleting the file: " + error.message);
-      });
-
-      // remove the fileDataObj from the list in the DB
-      const fileListPromise = removeFileData(fileId)
-      .catch((error) => {
-        alert("There was a problem removing the file reference: " + error.message);
-      });
-
-      // remove the fileDataObj from Redux store
-      const newFilesData = this.filesData.filter(fileNameObj => fileNameObj.id !== e.target.value);
-      this.props.setFilesData(newFilesData);
-
-      // After the Promises finish, reload the page to display correct data
-      Promise.all([storagePromise, fileListPromise])
-        .then(() => {
-          this.props.startLoadFilesData().then(() => {
-            history.push('/dashboard');
-          })
-        })
-    }
-  };
 
   render () {
     return (
@@ -136,26 +85,7 @@ export class DashboardPage extends React.Component {
           <div className="files-list">
             {this.props.filesData.map( (fileDataObj, x) => {
               return (
-                <div className="file-control" key={fileDataObj.id}>
-                  <a href="/" onClick={(e) => this.onFileClick(e, fileDataObj)} className="file-link">
-                    <div className="file">
-                      <div className="file-icon">
-                        <ion-icon name="document" />
-                      </div>
-                      <div className="file-name">
-                        {fileDataObj.filename}
-                      </div>
-                    </div>
-                  </a>
-                  <button
-                    type="button"
-                    name={fileDataObj.filename}
-                    onClick={this.onDeleteClick}
-                    value={fileDataObj.id}
-                    className="delete-button">
-                    Delete File
-                  </button>
-                </div>
+                <FileControl fileDataObj={fileDataObj} key={fileDataObj.id}/>
               )
             })}
           </div>

--- a/src/components/FileControl.js
+++ b/src/components/FileControl.js
@@ -12,11 +12,28 @@ export class FileControl extends React.Component {
 
     this.filename = props.fileDataObj.filename;
     this.fileId = props.fileDataObj.id;
+    this.state = {
+      progressBarVisibility: 'hide',
+      progress: 0.0,
+      deleteButtonDisabled: 'delete-button',
+      fileControlDisabled: 'file-link',
+      disabled: false
+    };
+
+
     if (props.uploadTask) {
       console.log(this.filename + ' has an upload task');
       props.uploadTask.on('state_changed', (snapshot) => {
         let progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
-        console.log(this.filename + ' Upload is ' + progress + '% done')
+        console.log(this.filename + ' Upload is ' + progress + '% done');
+        console.log('State is ' + snapshot.state);
+        this.setState({
+          progressBarVisibility: progress < 100 ? 'show' : 'hide',
+          progress,
+          deleteButtonDisabled: progress < 100 ? 'disable-delete-button' : 'delete-button',
+          fileControlDisabled: progress < 100 ? 'disable-file-link' : 'file-link',
+          disabled: progress < 100
+        })
       });
     }
   }
@@ -91,6 +108,11 @@ export class FileControl extends React.Component {
           className="delete-button">
           Delete File
         </button>
+        <progress
+          max={100}
+          value={this.state.progress}
+          className={this.state.progressBarVisibility}
+        />
       </div>
     )
   }

--- a/src/components/FileControl.js
+++ b/src/components/FileControl.js
@@ -15,8 +15,8 @@ export class FileControl extends React.Component {
     this.state = {
       progressBarVisibility: 'hide',
       progress: 0.0,
-      deleteButtonDisabled: 'delete-button',
-      fileControlDisabled: 'file-link',
+      deleteButtonStatus: 'delete-button',
+      fileControlStatus: 'file-link',
       disabled: false
     };
 
@@ -30,8 +30,8 @@ export class FileControl extends React.Component {
         this.setState({
           progressBarVisibility: progress < 100 ? 'show' : 'hide',
           progress,
-          deleteButtonDisabled: progress < 100 ? 'disable-delete-button' : 'delete-button',
-          fileControlDisabled: progress < 100 ? 'disable-file-link' : 'file-link',
+          deleteButtonStatus: progress < 100 ? 'disable-delete-button' : 'delete-button',
+          fileControlStatus: progress < 100 ? 'disable-file-link' : 'file-link',
           disabled: progress < 100
         })
       });
@@ -70,27 +70,33 @@ export class FileControl extends React.Component {
   onFileClick = (e, fileDataObj) => {
     e.preventDefault();
 
-    const filename = fileDataObj.filename;
-    getDownloadURL(filename)
-      .then( (url) => {
-        const xhr = new XMLHttpRequest();
-        xhr.responseType = 'blob';
-        xhr.onload = function(event) {
-          const blob = xhr.response;
-          saveAs(blob, filename)
-        };
-        xhr.open('GET', url);
-        xhr.send();
-      })
-      .catch( (error) => {
-        alert("An error occurred in the download/n" + error.message)
-      })
+    if (!this.state.disabled) {
+      const filename = fileDataObj.filename;
+      getDownloadURL(filename)
+        .then( (url) => {
+          const xhr = new XMLHttpRequest();
+          xhr.responseType = 'blob';
+          xhr.onload = function(event) {
+            const blob = xhr.response;
+            saveAs(blob, filename)
+          };
+          xhr.open('GET', url);
+          xhr.send();
+        })
+        .catch( (error) => {
+          alert("An error occurred in the download/n" + error.message)
+        })
+    }
   };
 
   render () {
     return (
       <div className="file-control" >
-        <a href="/" onClick={(e) => this.onFileClick(e, this.props.fileDataObj)} className="file-link">
+        <a
+          href="/"
+          onClick={(e) => this.onFileClick(e, this.props.fileDataObj)}
+          className={this.state.fileControlStatus}
+        >
           <div className="file">
             <div className="file-icon">
               <ion-icon name="document" />
@@ -105,7 +111,9 @@ export class FileControl extends React.Component {
           name={this.filename}
           onClick={this.onDeleteClick}
           value={this.fileId}
-          className="delete-button">
+          className={this.state.deleteButtonStatus}
+          disabled={this.state.disabled}
+        >
           Delete File
         </button>
         <progress

--- a/src/components/FileControl.js
+++ b/src/components/FileControl.js
@@ -15,7 +15,6 @@ export class FileControl extends React.Component {
     if (props.uploadTask) {
       console.log(this.filename + "has the upload task")
     }
-
   }
 
   onDeleteClick = (e) => {

--- a/src/components/FileControl.js
+++ b/src/components/FileControl.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import {connect} from 'react-redux';
+import {getDownloadURL, deleteFile, removeFileData} from '../firebase/firebase';
+import {saveAs} from 'file-saver/FileSaver';
+import {setFilesData, startLoadFilesData} from '../actions/files';
+import {history} from "../App";
+
+export class FileControl extends React.Component {
+  constructor(props) {
+    super(props);
+    this.filesData = props.filesData;
+
+    this.filename = props.fileDataObj.filename;
+    this.fileId = props.fileDataObj.id;
+  }
+
+  onDeleteClick = (e) => {
+    // const filename = e.target.name;
+    // const fileId = e.target.value;
+    if (window.confirm(this.filename + ' will be Deleted. This CANNOT be undone. Are you sure?')) {
+
+      // first remove the file from storage
+      const storagePromise = deleteFile(this.filename)
+        .catch((error) => {
+          alert("There was a problem deleting the file: " + error.message);
+        });
+
+      // remove the fileDataObj from the list in the DB
+      const fileListPromise = removeFileData(this.fileId)
+        .catch((error) => {
+          alert("There was a problem removing the file reference: " + error.message);
+        });
+
+      // remove the fileDataObj from Redux store
+      const newFilesData = this.filesData.filter(fileNameObj => fileNameObj.id !== this.fileId);
+      this.props.setFilesData(newFilesData);
+
+      // After the Promises finish, reload the page to display correct data
+      Promise.all([storagePromise, fileListPromise])
+        .then(() => {
+          this.props.startLoadFilesData().then(() => {
+            history.push('/dashboard');
+          })
+        })
+    }
+  };
+
+  onFileClick = (e, fileDataObj) => {
+    e.preventDefault();
+
+    const filename = fileDataObj.filename;
+    getDownloadURL(filename)
+      .then( (url) => {
+        const xhr = new XMLHttpRequest();
+        xhr.responseType = 'blob';
+        xhr.onload = function(event) {
+          const blob = xhr.response;
+          saveAs(blob, filename)
+        };
+        xhr.open('GET', url);
+        xhr.send();
+      })
+      .catch( (error) => {
+        alert("An error occurred in the download/n" + error.message)
+      })
+  };
+
+  render () {
+    return (
+      <div className="file-control" >
+        <a href="/" onClick={(e) => this.onFileClick(e, this.props.fileDataObj)} className="file-link">
+          <div className="file">
+            <div className="file-icon">
+              <ion-icon name="document" />
+            </div>
+            <div className="file-name">
+              {this.filename}
+            </div>
+          </div>
+        </a>
+        <button
+          type="button"
+          name={this.filename}
+          onClick={this.onDeleteClick}
+          value={this.fileId}
+          className="delete-button">
+          Delete File
+        </button>
+      </div>
+    )
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    filesData: state.filesData
+  }
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    setFilesData: (newFilesData) => dispatch(setFilesData(newFilesData)),
+    startLoadFilesData: () => dispatch(startLoadFilesData())
+  }
+};
+
+// ConnectedFileControl
+export default connect(mapStateToProps, mapDispatchToProps)(FileControl)

--- a/src/components/FileControl.js
+++ b/src/components/FileControl.js
@@ -13,7 +13,11 @@ export class FileControl extends React.Component {
     this.filename = props.fileDataObj.filename;
     this.fileId = props.fileDataObj.id;
     if (props.uploadTask) {
-      console.log(this.filename + "has the upload task")
+      console.log(this.filename + ' has an upload task');
+      props.uploadTask.on('state_changed', (snapshot) => {
+        let progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+        console.log(this.filename + ' Upload is ' + progress + '% done')
+      });
     }
   }
 

--- a/src/components/FileControl.js
+++ b/src/components/FileControl.js
@@ -12,11 +12,13 @@ export class FileControl extends React.Component {
 
     this.filename = props.fileDataObj.filename;
     this.fileId = props.fileDataObj.id;
+    if (props.uploadTask) {
+      console.log(this.filename + "has the upload task")
+    }
+
   }
 
   onDeleteClick = (e) => {
-    // const filename = e.target.name;
-    // const fileId = e.target.value;
     if (window.confirm(this.filename + ' will be Deleted. This CANNOT be undone. Are you sure?')) {
 
       // first remove the file from storage

--- a/src/css/DashboardPage.css
+++ b/src/css/DashboardPage.css
@@ -36,3 +36,12 @@
   background: red;
   color: white;
 }
+
+.disable-delete-button {
+  background: gray;
+  color: black;
+}
+
+.disable-file-link {
+  color: gray;
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -98,3 +98,11 @@ a {
   font-size: 1.4rem;
   font-style: italic;
 }
+
+.hide {
+  visibility: hidden;
+}
+
+.show {
+  visibility: visible;
+}

--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -37,16 +37,13 @@ export const uploadFile = (file) => {
   const storageRef = storage.ref();
   const filesRef = storageRef.child('files/' + user.uid + '/' + file.name);
   const uploadTask = filesRef.put(file);
-  uploadTask.on('state_changed', (snapshot) => {
-    let progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
-    console.log('Upload is ' + progress + '% done')
-  });
+
   return uploadTask;
 };
 
 export const addFileNameToFilesData = (file) => {
   const user = firebase.auth().currentUser;
-  firebase.database().ref('users/' + user.uid + '/files').push(file.name);
+  return firebase.database().ref('users/' + user.uid + '/files').push(file.name);
 }
 
 export const changeName = (firstName, lastName) => {

--- a/src/firebase/firebase.js
+++ b/src/firebase/firebase.js
@@ -36,7 +36,12 @@ export const uploadFile = (file) => {
   const storage = firebase.storage();
   const storageRef = storage.ref();
   const filesRef = storageRef.child('files/' + user.uid + '/' + file.name);
-  filesRef.put(file);
+  const uploadTask = filesRef.put(file);
+  uploadTask.on('state_changed', (snapshot) => {
+    let progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+    console.log('Upload is ' + progress + '% done')
+  });
+  return uploadTask;
 };
 
 export const addFileNameToFilesData = (file) => {


### PR DESCRIPTION
Move the rendering of each file element into a separate React component. Change the Dashboard page to use stateful implementation for the file list. Add a file to the file list using state instead of reloading the page each time. Add a progress indicator to each file icon indicating the upload progress. The progress indicator is made not visible when the upload completes. Make the file icon and the delete button gray and unresponsive until the upload completes. 

The page still reloads when a delete action is executed. 

closes #172 